### PR TITLE
pull request to stop exception being printed out on stderr

### DIFF
--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
@@ -1518,6 +1518,9 @@ public final class PySelection {
             while(documentOffset >= 0 && documentOffset < doc.getLength() && doc.get(documentOffset, 1).equals(".")){
                 String tok = extractActivationToken(doc, documentOffset, false).o1;
     
+                if (documentOffset == 0) {
+                	break;
+                }
                     
                 String c = doc.get(documentOffset-1, 1);
                 

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
@@ -784,6 +784,59 @@ public class PythonCompletionWithoutBuiltinsTest extends CodeCompletionTestsBase
     }
 
     /**
+     * Add tests that demonstrate behaviour when doc starts with a . 
+     */
+    public void testGetAckTok2() {
+        String strs[];
+        strs = PySelection.getActivationTokenAndQual(new Document("."), 1, false); 
+        assertEquals("", strs[0]);
+        assertEquals("", strs[1]);
+        
+        strs = PySelection.getActivationTokenAndQual(new Document(".a"), 1, false); 
+        assertEquals("", strs[0]);
+        assertEquals("", strs[1]);
+        
+        strs = PySelection.getActivationTokenAndQual(new Document(".a"), 2, false); 
+        assertEquals("", strs[0]);
+        assertEquals("a", strs[1]);
+        
+        ActivationTokenAndQual act = PySelection.getActivationTokenAndQual(new Document("."), 1, false, true); 
+        assertEquals("", act.activationToken);
+        assertEquals("", act.qualifier);
+        assertTrue(!act.changedForCalltip);
+        assertTrue(!act.alreadyHasParams);
+        assertTrue(!act.isInMethodKeywordParam);
+        
+        act = PySelection.getActivationTokenAndQual(new Document(".a"), 1, false, true); 
+        assertEquals("", act.activationToken);
+        assertEquals("", act.qualifier);
+        assertTrue(!act.changedForCalltip);
+        assertTrue(!act.alreadyHasParams);
+        assertTrue(!act.isInMethodKeywordParam);
+        
+        act = PySelection.getActivationTokenAndQual(new Document(".a"), 2, false, true); 
+        assertEquals("", act.activationToken);
+        assertEquals("a", act.qualifier);
+        assertTrue(!act.changedForCalltip);
+        assertTrue(!act.alreadyHasParams);
+        assertTrue(!act.isInMethodKeywordParam);
+        
+        act = PySelection.getActivationTokenAndQual(new Document(".abc"), 1, true, true); 
+        assertEquals("", act.activationToken);
+        assertEquals("abc", act.qualifier);
+        assertTrue(!act.changedForCalltip);
+        assertTrue(!act.alreadyHasParams);
+        assertTrue(!act.isInMethodKeywordParam);
+        
+        act = PySelection.getActivationTokenAndQual(new Document(".abc"), 2, true, true); 
+        assertEquals("", act.activationToken);
+        assertEquals("abc", act.qualifier);
+        assertTrue(!act.changedForCalltip);
+        assertTrue(!act.alreadyHasParams);
+        assertTrue(!act.isInMethodKeywordParam);
+    }
+
+    /**
      * @throws BadLocationException
      * @throws CoreException
      */


### PR DESCRIPTION
Fixed one of the cases when BadLocationException is printed to stdout because doc starts with a .

If the very first thing in a document that completions is requested for (either a text file or a line in an interactive console) stack traces like those below come out on stderr/out.

This change fixes the error, but probably doesn't go far enough in that the underlying printstacktrace is still in the code. 

I also added some basic tests that cause the error to happen, but the tests themselves don't fail because they don't attempt to monitor stderr. If the catch was changed to rethrow the exception, similar to the catch a little higher in the code, then the tests would be more useful.

documentOffset 0
theDoc.getLength() 1
org.eclipse.jface.text.BadLocationException
    at org.eclipse.jface.text.AbstractDocument.get(AbstractDocument.java:1038)
    at org.eclipse.core.internal.filebuffers.SynchronizableDocument.get(SynchronizableDocument.java:140)
    at org.python.pydev.core.docutils.PySelection.getActivationTokenAndQual(PySelection.java:1522)
    at org.python.pydev.core.docutils.PySelection.getActivationTokenAndQual(PySelection.java:1414)
    at org.python.pydev.editor.codecompletion.PythonCompletionProcessor.computeCompletionProposals(PythonCompletionProcessor.java:170)
    at org.python.pydev.editor.simpleassist.SimpleAssistProcessor.computeCompletionProposals(SimpleAssistProcessor.java:204)
    at org.eclipse.jface.text.contentassist.ContentAssistant.computeCompletionProposals(ContentAssistant.java:1834)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.computeProposals(CompletionProposalPopup.java:556)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.access$16(CompletionProposalPopup.java:553)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup$2.run(CompletionProposalPopup.java:488)
    at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.showProposals(CompletionProposalPopup.java:482)
    at org.eclipse.jface.text.contentassist.ContentAssistant$2.run(ContentAssistant.java:376)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:134)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4041)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3660)
    at org.eclipse.ui.internal.Workbench.runEventLoop(Workbench.java:2640)
    at org.eclipse.ui.internal.Workbench.runUI(Workbench.java:2604)
    at org.eclipse.ui.internal.Workbench.access$4(Workbench.java:2438)
    at org.eclipse.ui.internal.Workbench$7.run(Workbench.java:671)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:664)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:149)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:115)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:110)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:79)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:369)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:179)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:620)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:575)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1408)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1384)

documentOffset 0
theDoc.getLength() 1
org.eclipse.jface.text.BadLocationException
    at org.eclipse.jface.text.AbstractDocument.get(AbstractDocument.java:1038)
    at org.python.pydev.core.docutils.PySelection.getActivationTokenAndQual(PySelection.java:1522)
    at org.python.pydev.debug.newconsole.PydevConsoleInterpreter.getCompletions(PydevConsoleInterpreter.java:94)
    at org.python.pydev.debug.newconsole.PydevConsoleCompletionProcessor.computeCompletionProposals(PydevConsoleCompletionProcessor.java:92)
    at org.eclipse.jface.text.contentassist.ContentAssistant.computeCompletionProposals(ContentAssistant.java:1834)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.computeProposals(CompletionProposalPopup.java:556)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.access$16(CompletionProposalPopup.java:553)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup$2.run(CompletionProposalPopup.java:488)
    at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.showProposals(CompletionProposalPopup.java:482)
    at org.eclipse.jface.text.contentassist.ContentAssistant$2.run(ContentAssistant.java:376)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:134)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4041)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3660)
    at org.eclipse.ui.internal.Workbench.runEventLoop(Workbench.java:2640)
    at org.eclipse.ui.internal.Workbench.runUI(Workbench.java:2604)
    at org.eclipse.ui.internal.Workbench.access$4(Workbench.java:2438)
    at org.eclipse.ui.internal.Workbench$7.run(Workbench.java:671)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:664)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:149)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:115)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:110)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:79)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:369)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:179)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:620)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:575)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1408)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1384)
