### PR TITLE
add schemas to bin includes (updated)

### DIFF
--- a/plugins/org.python.pydev.debug/build.properties
+++ b/plugins/org.python.pydev.debug/build.properties
@@ -2,6 +2,7 @@ bin.includes = plugin.xml,\
                pysrc/,\
                CVS/,\
                META-INF/,\
+               schema/,\
                icons/,\
                pydev-debug.jar,\
                retroweaver-rt.jar,\

--- a/plugins/org.python.pydev.parser/build.properties
+++ b/plugins/org.python.pydev.parser/build.properties
@@ -2,6 +2,7 @@ source.parser.jar = src/
 output.parser.jar = bin/
 bin.includes = plugin.xml,\
                META-INF/,\
+               schema/,\
                parser.jar,\
                retroweaver-rt.jar,\
                LICENSE.txt

--- a/plugins/org.python.pydev/build.properties
+++ b/plugins/org.python.pydev/build.properties
@@ -2,6 +2,7 @@ bin.includes = plugin.xml,\
                icons/,\
                PySrc/,\
                META-INF/,\
+               schema/,\
                pydev.jar,\
                about.ini,\
                about.mappings,\


### PR DESCRIPTION
I would like to request that the schemas be added to the bin.includes of the build.properties. Having the schemas available eases my work when I create new extensions of PyDev, but don't have or can't have the source projects.

Thank you,
Jonah

(Note this replaces the earlier pull request that I closed because I wasn't requesting the right thing)
