### PR TITLE
Add a new property "sign_jars" to govern whether jars are signed.

### DIFF
--- a/builders/org.python.pydev.build/build.xml
+++ b/builders/org.python.pydev.build/build.xml
@@ -41,20 +41,34 @@
 	    </sequential>
 	</macrodef>
 	
-	
-	
-
 	<property environment="env" />
 	<property file="build_local.properties" />
 	<!-- Set is.windows property IF the OS is from the Windows family -->
 	<condition property="is.windows" value="true">
 		<os family="windows" />
 	</condition>
-	<!-- Set is.windows property IF the OS is from the Windows family -->
+	<!-- Set is.local_build property IF the local_build property is any true value -->
 	<condition property="is.local_build" value="true">
 		<istrue value="${local_build}"/>
 	</condition>
-	
+	<!-- sign_jars can be optionally set, but otherwise defaults to local_build
+	     Set is.sign_jars property IF the sign_jars property is any true value
+	     OR (the sign_jars property is unset AND the local_build property is any true value) -->
+	<condition property="is.sign_jars" value="true">
+		<and>
+			<isset property="sign_jars"/>
+			<istrue value="${sign_jars}"/>
+		</and>
+	</condition>
+	<condition property="is.sign_jars" value="true">
+		<and>
+			<not>
+				<isset property="sign_jars"/>
+			</not>
+			<istrue value="${local_build}"/>
+		</and>
+	</condition>
+
     <taskdef resource="net/sf/antcontrib/antcontrib.properties">
         <classpath>
             <pathelement location="ant-contrib/ant-contrib.jar" />

--- a/builders/org.python.pydev.build/customTargets.xml
+++ b/builders/org.python.pydev.build/customTargets.xml
@@ -352,7 +352,7 @@
     </target>
 	
     
-    <target name="signJars" if="is.local_build">
+    <target name="signJars" if="is.sign_jars">
         <echo message="Signing plugins and features at: ${p2.repo.dir}" />
         <signjar 
             alias="${KEYSTORE_ALIAS}" keystore="${KEYSTORE}"


### PR DESCRIPTION
Previously this was governed by property "local_build". I have added a separate property to control this, called "sign_jars". If not specified, "sign_jars" defaults to "local_build".
