### PR TITLE
Suppress all output to stderr/stdout by default

### DIFF
--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/RemoteDebuggerServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/RemoteDebuggerServer.java
@@ -153,8 +153,8 @@ public class RemoteDebuggerServer extends AbstractRemoteDebugger implements Runn
             target.startTransmission(socket);
             target.initialize();
             this.addTarget(target);
-        } catch (IOException e) {        
-            e.printStackTrace();
+        } catch (IOException e) {
+            Log.debug(e);
         }        
     }
 

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyGoToDefinition.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyGoToDefinition.java
@@ -217,7 +217,6 @@ public class PyGoToDefinition extends PyRefactorAction {
                 return defs;
             }
         } catch (Exception e) {
-            e.printStackTrace();
             PydevPlugin.log(e);
             String msg = e.getMessage();
             if(msg == null){

--- a/plugins/org.python.pydev.core/.options
+++ b/plugins/org.python.pydev.core/.options
@@ -1,0 +1,4 @@
+# Debugging options for the org.python.pydev.core plugin
+
+# Turn on general debugging for PyDev.
+org.python.pydev.core/debug=false

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/REF.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/REF.java
@@ -884,7 +884,7 @@ public class REF {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.debug(e);
         }finally{
             try {reader.close();} catch (IOException e1) {}
         }

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
@@ -592,7 +592,7 @@ public final class PySelection {
                 doc.replace(offset, length, "");
             }
         } catch (BadLocationException e) {
-            e.printStackTrace();
+           Log.debug(e);
         } 
     }
     
@@ -680,7 +680,7 @@ public final class PySelection {
                 doc.replace(offset, 0, contents);
             }
         } catch (BadLocationException e) {
-            e.printStackTrace();
+            Log.debug(e);
         } 
     }
 
@@ -1700,9 +1700,9 @@ public final class PySelection {
     
             }
         } catch (BadLocationException e) {
-            System.out.println("documentOffset "+documentOffset);
-            System.out.println("theDoc.getLength() "+doc.getLength());
-            e.printStackTrace();
+            Log.debug("documentOffset "+documentOffset);
+            Log.debug("theDoc.getLength() "+doc.getLength());
+            Log.debug(e);
         }
         
         String qualifier = "";

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCodeCoverageView.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCodeCoverageView.java
@@ -403,7 +403,7 @@ public class PyCodeCoverageView extends ViewPartWithOrientation {
                     openFileWithCoverageMarkers(realFile);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.debug(e);
             }
         }
     }

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoverage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoverage.java
@@ -221,7 +221,7 @@ public class PyCoverage {
             }
 
         } catch (Exception e1) {
-            e1.printStackTrace();
+            Log.debug(e1);
             throw new RuntimeException(e1);
         }
     }
@@ -315,7 +315,7 @@ public class PyCoverage {
                 }
                 
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.debug(e);
             }
         }
     }

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/DeferredWorkbenchAdapter.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/DeferredWorkbenchAdapter.java
@@ -10,6 +10,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.ui.DeferredDebugElementWorkbenchAdapter;
 import org.eclipse.ui.progress.IDeferredWorkbenchAdapter;
 import org.eclipse.ui.progress.IElementCollector;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.debug.model.remote.AbstractDebuggerCommand;
 import org.python.pydev.debug.model.remote.GetVariableCommand;
 import org.python.pydev.debug.model.remote.ICommandResponseListener;
@@ -112,7 +113,7 @@ public class DeferredWorkbenchAdapter extends DeferredDebugElementWorkbenchAdapt
                 Thread.sleep(10); //10 millis
             }
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
 
         if(commandVariables != null){

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IEditorInput;
 import org.python.pydev.core.bundle.ImageCache;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.debug.core.PydevDebugPlugin;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.editorinput.PydevFileEditorInput;
@@ -196,7 +197,7 @@ public class PyDebugModelPresentation implements IDebugModelPresentation {
         if (attribute.equals(IDebugModelPresentation.DISPLAY_VARIABLE_TYPE_NAMES)){
             displayVariableTypeNames = ((Boolean) value).booleanValue();
         }else{
-            System.err.println("setattribute");
+            Log.debug("setattribute");
         }
     }
 

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadListCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadListCommand.java
@@ -13,6 +13,7 @@ package org.python.pydev.debug.model.remote;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.debug.core.PydevDebugPlugin;
 import org.python.pydev.debug.model.AbstractDebugTarget;
 import org.python.pydev.debug.model.PyThread;
@@ -68,7 +69,7 @@ public class ThreadListCommand extends AbstractDebuggerCommand {
             threads = XMLUtils.ThreadsFromXML(target, payload);
         } catch (CoreException e) {
             PydevDebugPlugin.log(IStatus.ERROR, "LIST THREADS got an unexpected response "  + payload, null);
-            e.printStackTrace();
+            Log.debug(e);
         }
         done = true;
     }

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseProcess.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseProcess.java
@@ -58,7 +58,6 @@ public class JythonEclipseProcess extends Process {
                             "''", "'"+port+"'", "'"+clientPort+"'" //args
                             );
                     if(e != null){
-                        e.printStackTrace();
                         Log.log(e);
                     }
                 };

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParser.java
@@ -286,7 +286,7 @@ public class PyParser implements IPyParser {
         // Set up new listener
         this.document = doc;
         if (doc == null) {
-            System.err.println("No document in PyParser::setDocument?");
+            Log.debug("No document in PyParser::setDocument?");
             return;
         }
 

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar24/TreeBuilder24.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar24/TreeBuilder24.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import org.python.pydev.core.FullRepIterable;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.parser.grammarcommon.AbstractTreeBuilder;
 import org.python.pydev.parser.grammarcommon.Decorators;
 import org.python.pydev.parser.grammarcommon.DefaultArg;
@@ -406,7 +407,7 @@ public final class TreeBuilder24 extends AbstractTreeBuilder implements ITreeBui
             return new ImportFrom(makeName(NameTok.ImportModule), aliases, 0); //relative import is always level 0 here (only actually added on version 25)
 
         default:
-            System.out.println("Error at TreeBuilder: default not treated:"+n.getId());
+            Log.debug("Error at TreeBuilder: default not treated:"+n.getId());
             return null;
         }
     }

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar25/TreeBuilder25.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar25/TreeBuilder25.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.parser.grammarcommon.AbstractTreeBuilder;
 import org.python.pydev.parser.grammarcommon.ComprehensionCollection;
 import org.python.pydev.parser.grammarcommon.Decorators;
@@ -460,7 +461,7 @@ public final class TreeBuilder25 extends AbstractTreeBuilder implements ITreeBui
             return makeImportFrom25Onwards(arity);
 
         default:
-            System.out.println("Error at TreeBuilder: default not treated:"+n.getId());
+            Log.debug("Error at TreeBuilder: default not treated:"+n.getId());
             return null;
         }
     }

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar26/TreeBuilder26.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar26/TreeBuilder26.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.parser.grammarcommon.AbstractTreeBuilder;
 import org.python.pydev.parser.grammarcommon.ComprehensionCollection;
 import org.python.pydev.parser.grammarcommon.Decorators;
@@ -454,7 +455,7 @@ public final class TreeBuilder26 extends AbstractTreeBuilder implements ITreeBui
             return makeImportFrom25Onwards(arity);
             
         default:
-            System.out.println("Error at TreeBuilder: default not treated:"+n.getId());
+            Log.debug("Error at TreeBuilder: default not treated:"+n.getId());
             return null;
         }
     }

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar27/TreeBuilder27.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar27/TreeBuilder27.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.parser.grammarcommon.AbstractTreeBuilder;
 import org.python.pydev.parser.grammarcommon.ComprehensionCollection;
 import org.python.pydev.parser.grammarcommon.Decorators;
@@ -414,7 +415,7 @@ public final class TreeBuilder27 extends AbstractTreeBuilder implements ITreeBui
             return makeImportFrom25Onwards(arity);
             
         default:
-            System.out.println("Error at TreeBuilder: default not treated:"+n.getId());
+            Log.debug("Error at TreeBuilder: default not treated:"+n.getId());
             return null;
         }
     }

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar30/TreeBuilder30.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar30/TreeBuilder30.java
@@ -3,6 +3,7 @@ package org.python.pydev.parser.grammar30;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.parser.grammarcommon.AbstractTreeBuilder;
 import org.python.pydev.parser.grammarcommon.ComprehensionCollection;
 import org.python.pydev.parser.grammarcommon.Decorators;
@@ -508,7 +509,7 @@ public final class TreeBuilder30 extends AbstractTreeBuilder implements ITreeBui
             return makeImportFrom25Onwards(arity);
             
         default:
-            System.out.println("Error at TreeBuilder: default not treated:"+n.getId());
+            Log.debug("Error at TreeBuilder: default not treated:"+n.getId());
             return null;
         }
     }

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/JJTPythonGrammarState.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/JJTPythonGrammarState.java
@@ -8,6 +8,7 @@ package org.python.pydev.parser.grammarcommon;
 
 import java.lang.reflect.Constructor;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.FastStack;
 import org.python.pydev.core.structure.FastStringBuffer;
 import org.python.pydev.parser.PyParser;
@@ -195,7 +196,7 @@ public final class JJTPythonGrammarState implements IJJTPythonGrammarState{
         } catch (ParseException exc) {
             throw exc;
         } catch (Exception exc) {
-            exc.printStackTrace();
+            Log.debug(exc);
             throw new ParseException("Internal error:" + exc);
         }
         if (newNode == null) {

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/FastCharStream.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/FastCharStream.java
@@ -217,7 +217,7 @@ public final class FastCharStream implements CharStream {
                     System.arraycopy(buffer, initial, ret, 0, len);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.debug(e);
             }
         }
         if(DEBUG){

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriteStateV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriteStateV2.java
@@ -12,6 +12,7 @@ package org.python.pydev.parser.prettyprinterv2;
 import java.io.IOException;
 
 import org.python.pydev.core.docutils.StringUtils;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.FastStringBuffer;
 
 /**
@@ -62,7 +63,7 @@ public class WriteStateV2 implements IWriterEraser {
         try{
             indentation.delete(len-indentLen, len);
         }catch(Exception e){
-            e.printStackTrace();
+            Log.debug(e);
         }
         eraseIndent();
     }

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ModuleAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ModuleAdapter.java
@@ -31,6 +31,7 @@ import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.ISourceModule;
 import org.python.pydev.core.IToken;
 import org.python.pydev.core.MisconfigurationException;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.editor.codecompletion.revisited.AbstractASTManager;
 import org.python.pydev.editor.codecompletion.revisited.CompletionCache;
@@ -562,7 +563,7 @@ public class ModuleAdapter extends AbstractScopeNode<Module> {
                 }
                 selection = new TextSelection(doc, startOffset, endOffset - startOffset);
             }catch(BadLocationException e){
-                e.printStackTrace();
+                Log.debug(e);
             }
         }
         return normalizeSelection(selection);

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
@@ -101,6 +101,7 @@ import org.python.pydev.core.callbacks.ICallbackWithListeners;
 import org.python.pydev.core.docutils.PyPartitionScanner;
 import org.python.pydev.core.docutils.PySelection;
 import org.python.pydev.core.docutils.SyntaxErrorException;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.parser.ISimpleNode;
 import org.python.pydev.editor.actions.FirstCharAction;
 import org.python.pydev.editor.actions.OfflineAction;
@@ -308,7 +309,7 @@ public class PyEdit extends PyEditProjection implements IPyEdit, IGrammarVersion
 	                    }
 	                } catch (Exception e) {
 	                    //ignore
-	                    e.printStackTrace();
+	                    Log.debug(e);
 	                }
 	            }
 	        }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAction.java
@@ -27,6 +27,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.ITextEditorExtension;
 import org.eclipse.ui.texteditor.ITextEditorExtension2;
 import org.python.pydev.core.docutils.PySelection;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.FastStringBuffer;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.editor.autoedit.DefaultIndentPrefs;
@@ -259,7 +260,7 @@ public abstract class PyAction extends Action implements IEditorActionDelegate {
         }catch(IllegalStateException x){
             //ignore, workbench has still not been created
         }
-        e.printStackTrace();
+        Log.debug(e);
     }
 
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -31,6 +31,7 @@ import org.eclipse.ui.IPropertyListener;
 import org.python.pydev.core.Tuple;
 import org.python.pydev.core.docutils.PySelection;
 import org.python.pydev.core.docutils.PySelection.DocIterator;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.performanceeval.OptimizationRelatedConstants;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.editor.model.IModelListener;
@@ -92,7 +93,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener {
                         try {
                             sleep(100);
                         } catch (InterruptedException e) {
-                            e.printStackTrace();
+                            Log.debug(e);
                         }
                         modelT = (ProjectionAnnotationModel) editor.getAdapter(ProjectionAnnotationModel.class);
                         if (modelT != null) {
@@ -143,7 +144,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyEditProjection.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyEditProjection.java
@@ -25,6 +25,7 @@ import org.eclipse.ui.editors.text.TextEditor;
 import org.eclipse.ui.texteditor.IEditorStatusLine;
 import org.eclipse.ui.texteditor.SourceViewerDecorationSupport;
 import org.python.pydev.core.docutils.PythonPairMatcher;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.parser.IParserObserver;
 import org.python.pydev.editor.preferences.PydevEditorPrefs;
 import org.python.pydev.plugin.preferences.PydevPrefs;
@@ -92,7 +93,7 @@ public abstract class PyEditProjection extends TextEditor implements IParserObse
                 projectionViewer.doOperation(ProjectionViewer.TOGGLE);
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssignCompletionProposal.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssignCompletionProposal.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.ui.texteditor.link.EditorLinkedModeUI;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.uiutils.RunInUiThread;
 import org.python.pydev.editor.codecompletion.PyCompletionProposal;
 import org.python.pydev.plugin.PydevPlugin;
@@ -83,7 +84,7 @@ public class AssistAssignCompletionProposal extends PyCompletionProposal{
 
         } catch (Throwable x) {
             // ignore
-            x.printStackTrace();
+            Log.debug(x);
         }
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/templates/TemplateHelper.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/templates/TemplateHelper.java
@@ -12,6 +12,7 @@ import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.persistence.TemplateStore;
 import org.eclipse.ui.editors.text.templates.ContributionContextTypeRegistry;
 import org.eclipse.ui.editors.text.templates.ContributionTemplateStore;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.PydevPlugin;
 
 /**
@@ -42,7 +43,7 @@ public class TemplateHelper {
             try {
                 fStore.load();
             } catch (IOException e) {
-                e.printStackTrace();
+                Log.debug(e);
                 throw new RuntimeException(e);
             }
         }

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedModel.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedModel.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Display;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.editor.model.IModelListener;
 import org.python.pydev.parser.ErrorDescription;
@@ -167,7 +168,7 @@ public class ParsedModel implements IOutlineModel {
                 }
                 
             }else {
-                System.out.println("No old model root?");
+                Log.debug("No old model root?");
             }
         }catch(Throwable e){
             PydevPlugin.log(e);

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
@@ -405,7 +405,7 @@ public class PydevPlugin extends AbstractUIPlugin implements Preferences.IProper
      * @param errorLevel IStatus.[OK|INFO|WARNING|ERROR]
      */
     public static void log(int errorLevel, String message, Throwable e, boolean printToConsole) {
-        if(printToConsole){
+        if(Log.isDebugging() && printToConsole){
             if(errorLevel == IStatus.ERROR){
                 System.out.println("Error received...");
             }else{
@@ -418,11 +418,13 @@ public class PydevPlugin extends AbstractUIPlugin implements Preferences.IProper
             }
         }
         
-        try {
-            Status s = new Status(errorLevel, getPluginID(), errorLevel, message, e);
-            getDefault().getLog().log(s);
-        } catch (Throwable e1) {
-            //logging should never fail!
+        if (getDefault() != null) {
+            try {
+                Status s = new Status(errorLevel, getPluginID(), errorLevel, message, e);
+                getDefault().getLog().log(s);
+            } catch (Throwable e1) {
+                //logging should never fail!
+            }
         }
     }
 
@@ -660,6 +662,5 @@ public class PydevPlugin extends AbstractUIPlugin implements Preferences.IProper
         }
         return plugin.colorCache;
     }
-    
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/ThreadStreamReaderPrinter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/ThreadStreamReaderPrinter.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.FastStringBuffer;
 
 public class ThreadStreamReaderPrinter extends Thread {
@@ -43,7 +44,7 @@ public class ThreadStreamReaderPrinter extends Thread {
                 contents = new FastStringBuffer();
             }
         } catch (IOException ioe) {
-            ioe.printStackTrace();
+            Log.debug(ioe);
         }
     }
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeContentProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeContentProvider.java
@@ -10,6 +10,7 @@ import java.io.File;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
+import org.python.pydev.core.log.Log;
 
 public class FileTreeContentProvider implements ITreeContentProvider {
     public Object[] getChildren(Object element) {
@@ -35,7 +36,7 @@ public class FileTreeContentProvider implements ITreeContentProvider {
         }else if(element instanceof String){
             return new File((String) element).getParent();
         }
-        System.out.println("element not instance of File of String: " + element.getClass().getName() + " "
+        Log.debug("element not instance of File of String: " + element.getClass().getName() + " " 
                 + element.toString());
         return null;
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
@@ -438,7 +438,7 @@ public abstract class AbstractInterpreterManager implements IInterpreterManager 
                                 }
                                 
                             });
-                            System.out.println("Finished restoring information for: "+info.executableOrJar+" at: "+info.getExeAsFileSystemValidPath());
+                            Log.debug("Finished restoring information for: "+info.executableOrJar+" at: "+info.getExeAsFileSystemValidPath());
                         }
                     }
                     

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressOperation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressOperation.java
@@ -19,6 +19,7 @@ import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.uiutils.AsynchronousProgressMonitorDialog;
 
 /**
@@ -47,7 +48,7 @@ public class ProgressOperation extends WorkspaceModifyOperation {
             action.run();
             monitor.done();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
 
     }
@@ -66,9 +67,9 @@ public class ProgressOperation extends WorkspaceModifyOperation {
             monitorDialog.run(false, false, operation);
             // Perform the action
         } catch (InvocationTargetException e) {
-            e.printStackTrace();
+            Log.debug(e);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
 
     }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionError.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionError.java
@@ -16,6 +16,7 @@ import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.ui.UIConstants;
 
@@ -63,7 +64,7 @@ public class CompletionError implements ICompletionProposal, IPyCompletionPropos
         if(message == null){
             //NullPointerException
             if(error instanceof NullPointerException){
-                error.printStackTrace();
+                Log.debug(error);
                 message = "NullPointerException";
             }else{
                 message = "Null error message";

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCompletionProposal.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCompletionProposal.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
+import org.python.pydev.core.log.Log;
 
 
 /**
@@ -134,7 +135,7 @@ public class PyCompletionProposal implements ICompletionProposal, IPyCompletionP
                 }
             } catch (BadLocationException x) {
                 // ignore
-                x.printStackTrace();
+                Log.debug(x);
             }
             return;
         }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractASTManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractASTManager.java
@@ -388,7 +388,7 @@ public abstract class AbstractASTManager implements ICodeCompletionASTManager, S
             String message = e.getMessage();
             if(message == null){
                 if(e instanceof NullPointerException){
-                    e.printStackTrace();
+                    Log.debug(e);
                     message = "NullPointerException";
                 }else{
                     message = "Null error message";
@@ -731,7 +731,7 @@ public abstract class AbstractASTManager implements ICodeCompletionASTManager, S
 
             
         }else{
-            System.err.println("Module passed in is null!!");
+            Log.debug("Module passed in is null!!");
         }
         
         return EMPTY_ITOKEN_ARRAY;

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignAnalysis.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignAnalysis.java
@@ -19,6 +19,7 @@ import org.python.pydev.core.ICodeCompletionASTManager;
 import org.python.pydev.core.ICompletionState;
 import org.python.pydev.core.IModule;
 import org.python.pydev.core.IToken;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.editor.codecompletion.revisited.modules.SourceModule;
 import org.python.pydev.editor.codecompletion.revisited.modules.SourceToken;
@@ -92,7 +93,7 @@ public class AssignAnalysis {
             } catch (CompletionRecursionException e) {
                 //thats ok
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.debug(e);
                 throw new RuntimeException("Error when getting assign completions for:"+module.getName(), e);
             } catch (Throwable t) {
                 throw new RuntimeException("A throwable exception has been detected "+t.getClass());

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManager.java
@@ -628,7 +628,7 @@ public abstract class ModulesManager implements IModulesManager, Serializable {
             if (n != null) {
                 doAddSingleModule(createModulesKey(name, e.f), n);
             } else {
-                System.err.println("The module " + name + " could not be found nor created!");
+                Log.debug("The module " + name + " could not be found nor created!");
             }
         }
 

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledModule.java
@@ -107,7 +107,6 @@ public class CompiledModule extends AbstractModule{
                     setTokens(name, manager);
                 } catch (Exception e2) {
                     tokens = new HashMap<String, IToken>();
-                    e2.printStackTrace();
                     PydevPlugin.log(e2);
                 }
             }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
@@ -37,6 +37,7 @@ import org.python.pydev.core.Tuple3;
 import org.python.pydev.core.cache.Cache;
 import org.python.pydev.core.cache.LRUCache;
 import org.python.pydev.core.docutils.StringUtils;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.core.structure.FastStack;
 import org.python.pydev.editor.codecompletion.revisited.AbstractToken;
@@ -321,7 +322,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             //end cache
             
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
         }
         
         //now, let's get it from the cache... (which should be filled by now)
@@ -998,7 +999,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             
             return scope.getLocalTokens(line, col, false);
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
             return EMPTY_ITOKEN_ARRAY;
         }
     }
@@ -1013,7 +1014,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             
             return scopeVisitor.scope;
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
             return null;
         }
     }
@@ -1042,7 +1043,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             
             return scopeVisitor.scope.getScopeEndLine();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
             return -1;
         }
     }
@@ -1056,7 +1057,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             
             return scopeVisitor.scope.getIfMainLine();
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.debug(e);
             return -1;
         }
     }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/LocalScope.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/LocalScope.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.python.pydev.core.FullRepIterable;
 import org.python.pydev.core.ILocalScope;
 import org.python.pydev.core.IToken;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.FastStack;
 import org.python.pydev.editor.codecompletion.revisited.modules.SourceToken;
 import org.python.pydev.parser.jython.SimpleNode;
@@ -209,7 +210,7 @@ public class LocalScope implements ILocalScope {
                         }
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    Log.debug(e);
                 }
             }
         }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/AbstractShell.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/AbstractShell.java
@@ -715,7 +715,7 @@ public abstract class AbstractShell {
                     throw new RuntimeException("Couldn't find END@@ on received string.");
                 }
             } catch (RuntimeException e) {
-                e.printStackTrace();
+                Log.debug(e);
                 if (ret.length() > 500) {
                     ret = ret.substring(0, 499) + "...(continued)...";//if the string gets too big, it can crash Eclipse...
                 }


### PR DESCRIPTION
I would like to submit this pull request that prevents all output from going to stderr/stdout unless requested.

Using the mechanism described here:
http://wiki.eclipse.org/FAQ_How_do_I_use_the_platform_debug_tracing_facility%3F
wrap all System.out.println(...), System.err.println(...) and e.printStackTrace()
calls througout the code that did not already have a DEBUG guard or similar.

The majority of the work happens in Log.java, and the new .options file is in org.python.pydev.core

Thanks,
Jonah
