### PR TITLE
Fix Spurious ImportError in Python 3.2 on unittest failure

### DIFF
--- a/plugins/org.python.pydev.debug/pysrc/runfiles.py
+++ b/plugins/org.python.pydev.debug/pysrc/runfiles.py
@@ -43,28 +43,19 @@ def main():
 
     NOSE_FRAMEWORK = 1
     PY_TEST_FRAMEWORK = 2
+    test_framework = 0 #Default (pydev)
     try:
-        if found_other_test_framework_param:
-            test_framework = 0 #Default (pydev)
-            if found_other_test_framework_param == NOSE_PARAMS:
-                import nose
-                test_framework = NOSE_FRAMEWORK
-                
-            elif found_other_test_framework_param == PY_TEST_PARAMS:
-                import pytest
-                test_framework = PY_TEST_FRAMEWORK
-                
-            else:
-                raise ImportError()
-                
-        else:
-            raise ImportError()
-        
+        if found_other_test_framework_param == NOSE_PARAMS:
+            import nose
+            test_framework = NOSE_FRAMEWORK
+        elif found_other_test_framework_param == PY_TEST_PARAMS:
+            import pytest
+            test_framework = PY_TEST_FRAMEWORK
     except ImportError:
-        if found_other_test_framework_param:
-            sys.stderr.write('Warning: Could not import the test runner: %s. Running with the default pydev unittest runner.\n' % (
-                found_other_test_framework_param,))
-            
+        sys.stderr.write('Warning: Could not import the test runner: %s. Running with the default pydev unittest runner.\n' % (
+            found_other_test_framework_param,))
+
+    if test_framework == 0:
         pydev_runfiles.main(configuration)
         
     else:


### PR DESCRIPTION
When a Python unit test is run by selecting "Run As -> Python unit-test" in Pydev, if the test fails and the Python interpreter is Python 3.2 then a spurious ImportError is displayed in the output window prior the the _real_ traceback of the unit test failure.

For example, suppose you have a unit test like the one below (note that it unconditionally fails):

``` python
import unittest
class MyTest(unittest.TestCase):
    def test(self):
        self.fail("simulated failure")
```

If the Python interpreter used by Pydev is Python 2.7 then the output produced when "Run As -> Python unit-test" is selected is the following:

```
Finding files... done.
Importing test modules ... done.

======================================================================
FAIL: test (FailingTest.MyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\dev\PydevTest\src\FailingTest.py", line 5, in test
    self.fail("simulated failure")
AssertionError: simulated failure

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (failures=1)
```

The output above is expected.  However, if the Python interpreter used by PyDev is Python 3.2 then a spurious ImportError traceback is also printed to the screen prior to the traceback for the real failure:

```
Finding files... done.
Importing test modules ... done.

======================================================================
FAIL: test (FailingTest.MyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Program Files\eclipse\plugins\org.python.pydev.debug_1.6.4.2011010200\pysrc\runfiles.py", line     61, in main
    raise ImportError()
ImportError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\dev\PydevTest\src\FailingTest.py", line 5, in test
    self.fail("simulated failure")
AssertionError: simulated failure

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (failures=1)
```

The reason for the spurious ImportError is that in runfiles.py (part of Pydev) the entire unit test is actually run in the "except" block where ImportError was caught if no special unit test framework (such as "nose") was detected.  Python 3.2 has more advanced logic to implement exception chaining than Python 2.7 which is why the additional traceback for the ImportError is only printed when running in Python 3.2.  The fix is to simply extract the logic to run the unit tests to outside of the try/except(ImportError) block.

I tested this fix with both Python 2.7 and Python 3.2 interpreters with the scenario above.  I did not test nose or py.test.
