### PR TITLE
IPython Console for 0.11: Update competer to new API

### DIFF
--- a/plugins/org.python.pydev/PySrc/pydev_ipython_console_011.py
+++ b/plugins/org.python.pydev/PySrc/pydev_ipython_console_011.py
@@ -60,7 +60,7 @@ class PyDevFrontEnd:
         
         
     def complete(self, string):
-        return self.ipython.complete(string)
+        return self.ipython.complete(None, line=string)
     
     
         


### PR DESCRIPTION
The API used by PyDev for getting IPython to perform completions changed in v0.11. This pull request is to update how the completion is called.

Link for your convenience:
http://ipython.org/ipython-doc/stable/api/generated/IPython.core.interactiveshell.html#IPython.core.interactiveshell.InteractiveShell.complete

The result of not having this change is that:

> > > %c
> > > completes with %cd offered as a choice
> > > but
> > > %cd /
> > > does not complete directory names as expected.

Thanks,
Jonah
