### PR TITLE
Eclipse variables in interpreter info

### DIFF
--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/launching/PythonRunnerConfigTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/launching/PythonRunnerConfigTestWorkbench.java
@@ -18,6 +18,9 @@ import junit.framework.TestSuite;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.variables.IStringVariableManager;
+import org.eclipse.core.variables.IValueVariable;
+import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
@@ -85,16 +88,25 @@ public class PythonRunnerConfigTestWorkbench extends AbstractWorkbenchTestCase {
     
     public void testPythonCommandLine() throws Exception {
         PythonNature nature = PythonNature.getPythonNature(mod1);
-        
-        try{
+
+        // Create a temporary variable for testing
+        IStringVariableManager variableManager = VariablesPlugin.getDefault().getStringVariableManager();
+        IValueVariable myCustomVariable = variableManager.newValueVariable("pydev_python_runner_config_test_var", "", true, "my_custom_value");
+		variableManager.addVariables(new IValueVariable[]{ myCustomVariable});
+
+		try{
             IInterpreterManager manager = PydevPlugin.getPythonInterpreterManager(true);
             InterpreterInfo info = (InterpreterInfo) manager.getDefaultInterpreterInfo(false);
-            info.setEnvVariables(new String[]{"MY_CUSTOM_VAR_FOR_TEST=FOO", "MY_CUSTOM_VAR_FOR_TEST2=FOO2"});
+            info.setEnvVariables(new String[]{"MY_CUSTOM_VAR_FOR_TEST=FOO", "MY_CUSTOM_VAR_FOR_TEST2=FOO2", "MY_CUSTOM_VAR_WITH_VAR=${pydev_python_runner_config_test_var}"});
             
+            // Make sure variable hasn't been expanded too early
+            assertTrue(arrayContains(info.getEnvVariables(), "MY_CUSTOM_VAR_WITH_VAR=${pydev_python_runner_config_test_var}"));
+
             
             PythonRunnerConfig runnerConfig = createConfig();
             assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_FOR_TEST=FOO"));
             assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_FOR_TEST2=FOO2"));
+            assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_WITH_VAR=my_custom_value"));
             
             String[] argv = runnerConfig.getCommandLine(false); 
             assertFalse(arrayContains(argv, PythonRunnerConfig.getRunFilesScript()));
@@ -120,7 +132,6 @@ public class PythonRunnerConfigTestWorkbench extends AbstractWorkbenchTestCase {
             nature.setVersion(IPythonNature.PYTHON_VERSION_LATEST, IPythonNature.DEFAULT_INTERPRETER);
 
             ILaunchConfiguration config;
-            
             config = new LaunchShortcut().createDefaultLaunchConfiguration(FileOrResource.createArray(new IResource[] { mod1 }));
             ILaunchConfigurationWorkingCopy workingCopy = config.getWorkingCopy();
             HashMap<String, String> map = new HashMap<String, String>();
@@ -133,12 +144,14 @@ public class PythonRunnerConfigTestWorkbench extends AbstractWorkbenchTestCase {
             assertTrue(arrayContains(runnerConfig.envp, "VAR_SPECIFIED_IN_LAUNCH=BAR"));
             assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_FOR_TEST=FOO"));
             assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_FOR_TEST2=BAR2"));
+            assertTrue(arrayContains(runnerConfig.envp, "MY_CUSTOM_VAR_WITH_VAR=my_custom_value"));
         }catch (Throwable e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }finally{
             //restore the default!
             nature.setVersion(IPythonNature.PYTHON_VERSION_LATEST, IPythonNature.DEFAULT_INTERPRETER);
+            variableManager.removeVariables(new IValueVariable[]{ myCustomVariable});
         }
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
@@ -28,8 +28,12 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.zip.ZipFile;
 
+import org.eclipse.core.internal.variables.StringVariableManager;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.variables.IStringVariableManager;
+import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.python.pydev.core.ExtensionHelper;
@@ -115,6 +119,7 @@ public class InterpreterInfo implements IInterpreterInfo{
     
     private final Set<String> predefinedCompletionsPath = new TreeSet<String>();
     
+    
     /**
      * This is the way that the interpreter should be referred. Can be null (in which case the executable is
      * used as the name)
@@ -123,6 +128,19 @@ public class InterpreterInfo implements IInterpreterInfo{
 
     public ISystemModulesManager getModulesManager() {
         return modulesManager;
+    }
+
+    /**
+     * Variables manager to resolve variables in the interpreters environment.
+     * initStringVariableManager() creates an appropriate version when running 
+     * within Eclipse, for test the stringVariableManager can be set to
+     * an appropriate mock object
+     */
+    /*default*/ IStringVariableManager stringVariableManager;
+    {
+    	if (VariablesPlugin.getDefault() != null) {
+    		stringVariableManager = VariablesPlugin.getDefault().getStringVariableManager();
+    	}
     }
 
     /**
@@ -1169,17 +1187,11 @@ public class InterpreterInfo implements IInterpreterInfo{
             return env; //nothing to change
         }
         //Ok, it's not null... 
-        
-        if(env == null || env.length == 0){
-            //if the passed was null, just repass the ones contained here
-            return this.envVariables;
-        }
-        
-        //both not null, let's merge them
+        //let's merge them (env may be null/zero-length but we need to apply variable resolver to envVariables anyway)
         HashMap<String, String> hashMap = new HashMap<String, String>();
         
-        fillMapWithEnv(env, hashMap);
-        fillMapWithEnv(envVariables, hashMap, keysThatShouldNotBeUpdated); //will override the keys already there unless they're in keysThatShouldNotBeUpdated
+        fillMapWithEnv(env, hashMap, null, null);
+        fillMapWithEnv(envVariables, hashMap, keysThatShouldNotBeUpdated, stringVariableManager); //will override the keys already there unless they're in keysThatShouldNotBeUpdated
         
         String[] ret = createEnvWithMap(hashMap);
         
@@ -1197,19 +1209,28 @@ public class InterpreterInfo implements IInterpreterInfo{
         return ret;
     }
 
-    public static void fillMapWithEnv(String[] env, HashMap<String, String> hashMap) {
-        fillMapWithEnv(env, hashMap, null);
-    }
-    
-    public static void fillMapWithEnv(String[] env, HashMap<String, String> hashMap, Set<String> keysThatShouldNotBeUpdated) {
+    public static void fillMapWithEnv(String[] env, HashMap<String, String> hashMap, Set<String> keysThatShouldNotBeUpdated, IStringVariableManager manager) {
+    	if (env == null || env.length == 0) {
+    		// nothing to do
+    		return;
+    	}
+    	
         if(keysThatShouldNotBeUpdated == null){
-            keysThatShouldNotBeUpdated = new HashSet<String>();
+            keysThatShouldNotBeUpdated = Collections.emptySet();
         }
 
         for(String s: env){
             Tuple<String, String> sp = StringUtils.splitOnFirst(s, '=');
             if(sp.o1.length() != 0 && sp.o2.length() != 0 && !keysThatShouldNotBeUpdated.contains(sp.o1)){
-                hashMap.put(sp.o1, sp.o2);
+            	String value = sp.o2;
+            	if (manager != null) {
+            		try {
+						value = manager.performStringSubstitution(value, false);
+					} catch (CoreException e) {
+						// Unreachable as false passed to reportUndefinedVariables above
+					}
+            	}
+                hashMap.put(sp.o1, value);
             }
         }
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
@@ -38,7 +38,8 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
         HashMap<String, String> map = new HashMap<String, String>();
         String[] envVariables = info.getEnvVariables();
         if(envVariables != null){
-            InterpreterInfo.fillMapWithEnv(envVariables, map);
+            // We don't want to perform string substitution here nor exclude any variables
+            InterpreterInfo.fillMapWithEnv(envVariables, map, null, null);
             this.attributes.put(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, map);
         }else{
             this.attributes.remove(ILaunchManager.ATTR_APPEND_ENVIRONMENT_VARIABLES);

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 
+
 import junit.framework.TestCase;
 
 /**
@@ -143,11 +144,14 @@ public class InterpreterInfoTest extends TestCase {
         assertEquals(info8, InterpreterInfo.fromString(s, false));
         
     }
-    
-    private void compareArray(String []a, String[] b) {
-        if(!Arrays.equals(a, b)){
-            fail(Arrays.asList(a)+" != "+ Arrays.asList(b));
-        }
+
+    /**
+     * Compare whether the environment in envA is the same as envB
+     * @param envA
+     * @param envB
+     */
+    private void compareEnvironments(String []envA, String[] envB) {
+        assertEquals(new HashSet<String>(Arrays.asList(envA)), new HashSet<String>(Arrays.asList(envB)));
     }
     
     public void testInfo3() throws Exception {
@@ -165,7 +169,7 @@ public class InterpreterInfoTest extends TestCase {
         assertEquals(info.getStringSubstitutionVariables(), newInfo.getStringSubstitutionVariables());
         assertEquals(info, newInfo);
         assertEquals(newInfo, info);
-        compareArray(info.getEnvVariables(), newInfo.getEnvVariables());
+        compareEnvironments(info.getEnvVariables(), newInfo.getEnvVariables());
         newInfo.setEnvVariables(null);
         newInfo.setStringSubstitutionVariables(null);
         assertFalse(info.equals(newInfo));
@@ -179,13 +183,38 @@ public class InterpreterInfoTest extends TestCase {
         String[] original1 = new String[]{"LIBPATH=k:\\foo", "PATH=c:\\bin;d:\\bin"};
         info.setEnvVariables(original1);
         
-        compareArray(info.updateEnv(null), original1);
+        compareEnvironments(info.updateEnv(null), original1);
         
-        compareArray(info.updateEnv(new String[0]), original1);
+        compareEnvironments(info.updateEnv(new String[0]), original1);
         
         String[] original2 = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin2"};
         String[] expected2 = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin"};
-        assertEquals(new HashSet<String>(Arrays.asList(info.updateEnv(original2))), new HashSet<String>(Arrays.asList(expected2)));
+        compareEnvironments(info.updateEnv(original2), expected2);
+    }
+    
+
+    public void testVariableExpansion() throws Exception {
+        InterpreterInfo info = new InterpreterInfo("2.5", "c:\\bin\\python.exe", new ArrayList<String>());
+        MockStringVariableManager manager = new MockStringVariableManager();
+        manager.addMockVariable("var1", "value1");
+        info.stringVariableManager = manager;
+        String[] variableInInfo = new String[]{"LIBPATH=k:\\foo", "PATH=c:\\bin;d:\\bin", "ENV1=${var1}"};
+        info.setEnvVariables(variableInInfo);
+        
+        // echeck expected output when no environment is being added to
+        String[] expected1 = new String[]{"LIBPATH=k:\\foo", "PATH=c:\\bin;d:\\bin", "ENV1=value1"};
+        compareEnvironments(info.updateEnv(null), expected1);
+        compareEnvironments(info.updateEnv(new String[0]), expected1);
+        
+        // check expected output when there is an input environment
+        String[] inputEnv = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin2", "ENV1=some_other_value"};
+        String[] expected2 = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin", "ENV1=value1"};
+        compareEnvironments(info.updateEnv(inputEnv), expected2);
+        
+        // make sure that variables in the input (system) environment are not expanded
+        String[] original3 = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin2", "ENV2=${var1}"};
+        String[] expected3 = new String[]{"LIBPATH=k:\\foo", "boo=boo", "PATH=c:\\bin;d:\\bin", "ENV2=${var1}", "ENV1=value1"};
+        compareEnvironments(info.updateEnv(original3), expected3);
     }
     
     

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/MockStringVariableManager.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/MockStringVariableManager.java
@@ -1,0 +1,119 @@
+package org.python.pydev.ui.pythonpathconf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import junit.framework.AssertionFailedError;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.variables.IDynamicVariable;
+import org.eclipse.core.variables.IStringVariable;
+import org.eclipse.core.variables.IStringVariableManager;
+import org.eclipse.core.variables.IValueVariable;
+import org.eclipse.core.variables.IValueVariableListener;
+
+/**
+ * A mock implementation of IStringVariableManager suitable to test {@link InterpreterInfo#updateEnv(String[])}
+ */
+final class MockStringVariableManager implements
+		IStringVariableManager {
+	
+	private Map<String, String> mockVariables = new HashMap<String, String>();
+	
+	public void addMockVariable(String variable, String value) {
+		mockVariables.put(variable, value);
+	}
+
+	@Override
+	public String performStringSubstitution(String expression,
+			boolean reportUndefinedVariables) throws CoreException {
+		if (reportUndefinedVariables) {
+			throw new AssertionFailedError("reportUndefinedVariables only supports false");
+		}
+		for (Entry<String, String> entry : mockVariables.entrySet()) {
+			expression = expression.replaceAll(Pattern.quote("${" + entry.getKey() + "}"), Matcher.quoteReplacement(entry.getValue()));
+		}
+		return expression;
+	}
+
+	@Override
+	public String performStringSubstitution(String expression)
+			throws CoreException {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public void validateStringVariables(String expression) throws CoreException {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public void removeVariables(IValueVariable[] variables) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public void removeValueVariableListener(IValueVariableListener listener) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IValueVariable newValueVariable(String name, String description,
+			boolean readOnly, String value) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IValueVariable newValueVariable(String name, String description) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IStringVariable[] getVariables() {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IValueVariable[] getValueVariables() {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IValueVariable getValueVariable(String name) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IDynamicVariable[] getDynamicVariables() {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public IDynamicVariable getDynamicVariable(String name) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public String getContributingPluginId(IStringVariable variable) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public String generateVariableExpression(String varName, String arg) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public void addVariables(IValueVariable[] variables) throws CoreException {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+	@Override
+	public void addValueVariableListener(IValueVariableListener listener) {
+		throw new AssertionFailedError("Unexpected method call in MockStringVariableManager");
+	}
+
+}


### PR DESCRIPTION
This pull request is to allow environment variables in the interpreter info to contain eclipse variables.

Note that if environment variables added to individual launch configs correctly support eclipse variables.
