### PR TITLE
Build script fix

### DIFF
--- a/builders/org.python.pydev.build/build.xml
+++ b/builders/org.python.pydev.build/build.xml
@@ -81,7 +81,9 @@
          ================================= -->
 	<target name="doit" description="Builds the PyDev feature" depends="generate.build.properties,get.revision,generate.base">
 		<java jar="${baseLocation}/plugins/${launcher.plugin}.jar" fork="true" failonerror="yes">
-			<arg line="-application org.eclipse.ant.core.antRunner -buildfile ${baseLocation}/plugins/${builder.plugin}/scripts/build.xml -Dbuilder=${basedir} -Dbuild.revision=${build.revision} -nosplash" />
+			<jvmarg value="-Xmx512m" />
+			<jvmarg value="-XX:MaxPermSize=256m" />
+			<arg line="-nosplash -application org.eclipse.ant.core.antRunner -buildfile ${baseLocation}/plugins/${builder.plugin}/scripts/build.xml -Dbuilder=${basedir} -Dbuild.revision=${build.revision}" />
 		</java>
 		<antcall target="categorize" />
 	</target>


### PR DESCRIPTION
This fixes a typo in the build script. The typo resulted in cleanAfter never running.
