### PR TITLE
Early startup of PyDev Scripting console

### DIFF
--- a/plugins/org.python.pydev.jython/plugin.xml
+++ b/plugins/org.python.pydev.jython/plugin.xml
@@ -18,7 +18,7 @@
    <extension
          point="org.eclipse.ui.startup">
       <startup
-            class="org.python.pydev.jython.JythonPlugin"></startup>
+            class="org.python.pydev.jython.JythonPluginEarlyStartup"></startup>
    </extension>
 
 </plugin>

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPlugin.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPlugin.java
@@ -45,7 +45,7 @@ import org.python.util.PythonInterpreter;
 /**
  * The main plugin class to be used in the desktop.
  */
-public class JythonPlugin extends AbstractUIPlugin implements IStartup {
+public class JythonPlugin extends AbstractUIPlugin {
     
     private static final boolean DEBUG = false;
     public static boolean DEBUG_RELOAD = true;
@@ -602,14 +602,15 @@ public class JythonPlugin extends AbstractUIPlugin implements IStartup {
     public static IInteractiveConsole newInteractiveConsole() {
         return new InteractiveConsoleWrapper();
     }
+    
 
 	/**
-	 * Create the PyDev Scripting as part of the Eclipse startup. This is done
-	 * as part of startup so that future creations of IPythonInterpreter (with
-	 * newPythonInterpreter) don't cause the PyDev Scripting console to pop-up
-	 * on top of the current interactive console.
+	 * Create the PyDev Scripting as part of the Eclipse startup. This can be
+	 * done as part of startup so that future creations of IPythonInterpreter
+	 * (with newPythonInterpreter) don't cause the PyDev Scripting console to
+	 * pop-up on top of the current interactive console.
 	 */
-	public void earlyStartup() {
+	public void createPyDevScriptingConsole() {
 		if (fConsole == null) {
 			Display.getDefault().asyncExec(new Runnable() {
 				public void run() {
@@ -618,4 +619,5 @@ public class JythonPlugin extends AbstractUIPlugin implements IStartup {
 			});
 		}
 	}
+    
 }

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPluginEarlyStartup.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPluginEarlyStartup.java
@@ -1,0 +1,19 @@
+package org.python.pydev.jython;
+
+import org.eclipse.ui.IStartup;
+
+/**
+ * This class exists solely so that a different class than 
+ * the activator can be provided to do the early startup.
+ * 
+ * See the documentation for earlyStartup as to why
+ * the earlyStartup should not be in JythonPlugin 
+ * directly.
+ */
+public class JythonPluginEarlyStartup implements IStartup {
+
+	public void earlyStartup() {
+		JythonPlugin.getDefault().createPyDevScriptingConsole();
+	}
+
+}


### PR DESCRIPTION
Hi Fabio,

Please find details below of a small pull request.

Create the PyDev Scripting as part of the Eclipse startup. This is done
as part of startup so that future creations of IPythonInterpreter (with
newPythonInterpreter) don't cause the PyDev Scripting console to pop-up
on top of the current interactive console.

A particular case that hits regularly is if the PyDev Scripting console
has not yet been created and you request an completion in a pydev
interactive console, the scripting console is then created, popping up
on top of the interactive console the completion was requested on.

This behaviour can easily be overridden by unchecking "Jython Plug-in" in
the "Startup and Shutdown" Preference page.

Thanks,
Jonah
