### PR TITLE
Fix PythonPath ordering issue for launches and Workspace Python Consoles

### DIFF
--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
@@ -8,11 +8,9 @@ package org.python.pydev.debug.newconsole.env;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.ui.DebugUITools;
@@ -39,11 +37,12 @@ import org.python.pydev.debug.newconsole.prefs.InteractiveConsolePrefs;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.nature.PythonNature;
+import org.python.pydev.plugin.nature.SystemPythonNature;
 
 /**
  * Helper to choose which kind of jython run will it be.
  */
-final class ChooseProcessTypeDialog extends Dialog {
+public final class ChooseProcessTypeDialog extends Dialog {
     
     private Button checkboxForCurrentEditor;
 
@@ -270,32 +269,26 @@ final class ChooseProcessTypeDialog extends Dialog {
                         interpreter, this.interpreterManager)), nature);
 
             }
-            
-            //we need to get the natures matching the one selected in all the projects.
-            IWorkspace w = ResourcesPlugin.getWorkspace();
-            HashSet<String> pythonpath = new HashSet<String>();
-            for(IProject p:w.getRoot().getProjects()){
+
+            // Iterate over all the workspace projects adding the individual python-paths
+            for(IProject p : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
                 PythonNature nature = PythonNature.getPythonNature(p);
                 try{
                     if(nature != null){
                         if(nature.getRelatedInterpreterManager() == this.interpreterManager){
                             natures.add(nature);
-                            List<String> completeProjectPythonPath = nature.getPythonPathNature().
-                                    getCompleteProjectPythonPath(interpreter, this.interpreterManager);
-                            if(completeProjectPythonPath != null){
-                                pythonpath.addAll(completeProjectPythonPath);
-                            }else{
-                                Log.logInfo("Unable to get pythonpath for project: "+nature.getProject()+" (initialization not finished).");
-                            }
                         }
                     }
                 }catch(Exception e){
                     Log.log(e);
                 }
             }
+
+            // Get the complete python path from the system python path manager
+            Collection<String> pythonpath = new SystemPythonNature(this.interpreterManager, interpreter).getPythonPathNature().getCompleteProjectPythonPath(interpreter, this.interpreterManager);
             return new Tuple<Collection<String>, IPythonNature>(pythonpath, null);
         }
-        
+
         return null;
     }
 

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/IProcessFactory.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/IProcessFactory.java
@@ -212,15 +212,12 @@ public class IProcessFactory {
         launch.setAttribute(INTERACTIVE_LAUNCH_PORT, ""+port);
 
 		File scriptWithinPySrc = PydevPlugin.getScriptWithinPySrc("pydevconsole.py");
-		Collection<String> extraPath = pythonpath;
 		if (InteractiveConsolePrefs.getConsoleConnectVariableView()
 				&& interpreterManager.getInterpreterType() != IInterpreterManager.INTERPRETER_TYPE_JYTHON_ECLIPSE) {
-			// Add PydevDebugPlugin's pysrc so we can access pydevd
-			extraPath = new HashSet<String>();
-			extraPath.addAll(pythonpath);
-			extraPath.add(PydevDebugPlugin.getPySrcPath().getAbsolutePath());
+			// Add PydevDebugPlugin's PySrc so we can access pydevd
+		    pythonpath.add(PydevDebugPlugin.getPySrcPath().getAbsolutePath());
 		}
-        String pythonpathEnv = SimpleRunner.makePythonPathEnvFromPaths(extraPath);
+        String pythonpathEnv = SimpleRunner.makePythonPathEnvFromPaths(pythonpath);
         String[] commandLine;
         switch(interpreterManager.getInterpreterType()){
         


### PR DESCRIPTION
- Ordering of the paths is important: don't put them into a raw HashSet
- Make the WS interpreter's python paths come _before_ the
  per-Project python paths.  This ensures that the IPython pythonpath
  is the same as an externally invoked ipython / python process
- Move the logic for the Workspace python path creation to the
  SystemPythonPathNature
- Fix a typo in SystemPythonPathNature's name
