### PR TITLE
Console cursor shouldn't need to be next to the '>>>' for console entry to work 

### DIFF
--- a/plugins/org.python.pydev/src_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleViewer.java
+++ b/plugins/org.python.pydev/src_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleViewer.java
@@ -115,13 +115,13 @@ public class ScriptConsoleViewer extends TextConsoleViewer implements IScriptCon
         public void verifyKey(VerifyEvent event) {
             try {
                 if (event.character != '\0') { // Printable character
-                    
-                    if(Character.isLetter(event.character) && (event.stateMask == 0 || (event.stateMask & SWT.SHIFT) != 0)){
+
+                    if(Character.isLetter(event.character) && (event.stateMask == 0 || (event.stateMask & SWT.SHIFT) != 0)
+                            || Character.isWhitespace(event.character)){
                         //it's a valid letter without any stateMask (so, just entering regular text or upper/lowercase -- if shift is there).
                         if (!isSelectedRangeEditable()) {
                             getTextWidget().setCaretOffset(getDocument().getLength());
                         }
-                        
                     }
 
                     if (!isSelectedRangeEditable()) {


### PR DESCRIPTION
Whitespace characters, such as newline, entered should be sent to the end of the console.

It's a bit odd that the logic for console cursor fixing up is spread about in so many places.  There's:
- ScriptConsoleViewer#KeyChecker (here)
- ScriptConsoleSytledText#changeSelectionToEditableRange
- ScriptConsoleDocumentListener#processAdditions

The first is used on key-press, the second during cut / drop / paste, the last happens before the console changes.  I wonder if there's a way to better unify this logic...

More worryingly, I can get instances where getCommandLineLength() is negative (this happens if you disable the cursor move in ScriptConsoleViewer#KeyChecker and press enter). Weird.
