### PR TITLE
Switch from cygwin_conv_to_win32_path to cygwin_conv_path

### DIFF
--- a/plugins/org.python.pydev/pysrc/interpreterInfo.py
+++ b/plugins/org.python.pydev/pysrc/interpreterInfo.py
@@ -63,7 +63,11 @@ if sys.platform == "cygwin":
 
         retval = ctypes.create_string_buffer(MAX_PATH)
         path = fullyNormalizePath(path)
-        ctypes.cdll.cygwin1.cygwin_conv_to_win32_path(path, retval)  # @UndefinedVariable
+        
+        CCP_POSIX_TO_WIN_A = 0
+        
+        # ctypes.cdll.cygwin1.cygwin_conv_to_win32_path(path, retval)  # @UndefinedVariable
+         ctypes.cdll.cygwin1.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
         return retval.value
 
 else:


### PR DESCRIPTION
cygwin_conv_to_win32_path is deprecated and actually causes the script to crash under Cygwin 1.7.25 with Python 2.7.5. This simple change fixes the issue.
