### PR TITLE
Fix the error for "shell with django environment" with Django 1.6

### DIFF
--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoShell.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoShell.java
@@ -22,6 +22,7 @@ import org.python.pydev.debug.newconsole.PydevConsoleInterpreter;
 import org.python.pydev.debug.newconsole.env.PydevIProcessFactory;
 import org.python.pydev.debug.newconsole.env.PydevIProcessFactory.PydevConsoleLaunchInfo;
 import org.python.pydev.django.launching.DjangoConstants;
+import org.python.pydev.django.nature.DjangoNature;
 import org.python.pydev.plugin.nature.PythonNature;
 import org.python.pydev.shared_ui.EditorUtils;
 
@@ -101,8 +102,20 @@ public class DjangoShell extends DjangoAction {
             String importStr = "";//"from " + selectedProject.getName() + " import settings;";
             importStr = "import " + settingsModule + " as settings;";
 
-            consoleFactory.createConsole(interpreter, "\nfrom django.core import management;" + importStr
-                    + "management.setup_environ(settings)\n");
+            DjangoNature djangoNature = DjangoNature.getDjangoNature(selectedProject);
+            String djangoVersion = DjangoNature.DJANGO_14_OR_15;
+            if (djangoNature != null) {
+                djangoVersion = djangoNature.getVersion();
+            }
+
+            if (djangoVersion == DjangoNature.DJANGO_11_OR_EARLIER || djangoVersion == DjangoNature.DJANGO_12_OR_13
+                    || djangoVersion == DjangoNature.DJANGO_14_OR_15) {
+                consoleFactory.createConsole(interpreter, "\nfrom django.core import management;" + importStr
+                        + "management.setup_environ(settings)\n");
+            } else {
+                consoleFactory.createConsole(interpreter, "\nimport django.conf;" + importStr
+                        + "django.conf.settings.configure();\n");
+            }
 
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
With Django 1.6, right click the project

django --> shell with django environment:

There is an error there, which makes the console cant run Django related stuff

The command there:

```
from django.core import management;import test1.settings as  settings;management.setup_environ(settings)
```

Error:

```
Traceback (most recent call last): File "", line 1, in AttributeError: 'module' object has no attribute 'setup_environ'
```

Reason:

According to the document, this method is [deprecated](https://docs.djangoproject.com/en/dev/releases/1.4/#django-core-management-setup-environ) in Django 1.4.

(First time to modify the opensource project, it maybe a little ugly :) )
